### PR TITLE
ENG-3643 Added debug logging utility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,12 @@
     "semi": "off",
     "object-curly-spacing": "off",
     "comma-dangle": "off",
-    "unicorn/prefer-module": "off"
+    "unicorn/prefer-module": "off",
+    "node/no-extraneous-import": [
+      "error",
+      {
+        "allowModules": ["debug"]
+      }
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.1
 
 ## `entando-bundle-cli init NAME`
 
-Performs the scaffolding of a bundle project (we'll add the possibility to init from hub later)
+Performs the scaffolding of a Bundle project (we'll add the possibility to init from hub later)
 
 ```
 USAGE
@@ -73,7 +73,7 @@ FLAGS
   --version=<value>  project version
 
 DESCRIPTION
-  Performs the scaffolding of a bundle project (we'll add the possibility to init from hub later)
+  Performs the scaffolding of a Bundle project (we'll add the possibility to init from hub later)
 
 EXAMPLES
   $ entando-bundle-cli init my-bundle
@@ -96,6 +96,8 @@ nvm use
 
 If you are receiving `command not found` errors while executing pre-commit hooks with Husky using `nvm`, please refer to https://typicode.github.io/husky/#/?id=command-not-found
 
+## Debugging
+
 To print debug information define a static `debug` function using the `debugFactory`:
 
 ```
@@ -105,5 +107,11 @@ private static debug = debugFactory(MyClass)
 Debug output can be enabled using the following environment variable:
 
 ```
-ENTANDO_CLI_DEBUG=true
+ENTANDO_BUNDLE_CLI_DEBUG=true
+```
+
+Debug output is sent to stderr, so you can redirect it to a file in the following way:
+
+```
+entando-bundle-cli command 2>log.txt
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.1.1
 
 ## `entando-bundle-cli init NAME`
 
-performs the scaffolding of an empty bundle project
+Performs the scaffolding of a bundle project (we'll add the possibility to init from hub later)
 
 ```
 USAGE
@@ -73,7 +73,7 @@ FLAGS
   --version=<value>  project version
 
 DESCRIPTION
-  performs the scaffolding of an empty bundle project
+  Performs the scaffolding of a bundle project (we'll add the possibility to init from hub later)
 
 EXAMPLES
   $ entando-bundle-cli init my-bundle
@@ -95,3 +95,15 @@ nvm use
 ```
 
 If you are receiving `command not found` errors while executing pre-commit hooks with Husky using `nvm`, please refer to https://typicode.github.io/husky/#/?id=command-not-found
+
+To print debug information define a static `debug` function using the `debugFactory`:
+
+```
+private static debug = debugFactory(MyClass)
+```
+
+Debug output can be enabled using the following environment variable:
+
+```
+ENTANDO_CLI_DEBUG=true
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,6 +1072,15 @@
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/expect": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
@@ -1110,6 +1119,12 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
       "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@oclif/test": "2.1.0",
     "@types/chai": "4.3.1",
+    "@types/debug": "^4.1.7",
     "@types/mocha": "9.1.0",
     "@types/node": "17.0.25",
     "chai": "4.3.6",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,7 @@ const DEFAULT_VERSION = "0.0.1"
 
 export default class Init extends Command {
   static description =
-    "Performs the scaffolding of a bundle project (we'll add the possibility to init from hub later)"
+    "Performs the scaffolding of a Bundle project (we'll add the possibility to init from hub later)"
 
   static examples = [
     "$ entando-bundle-cli init my-bundle",

--- a/src/services/debug-factory-service.ts
+++ b/src/services/debug-factory-service.ts
@@ -12,7 +12,8 @@ export default function debugFactory(
 
   return (message: string, ...args: any[]) => {
     extendedDebugger.enabled =
-      extendedDebugger.enabled || process.env.ENTANDO_CLI_DEBUG === "true"
+      extendedDebugger.enabled ||
+      process.env.ENTANDO_BUNDLE_CLI_DEBUG === "true"
     if (extendedDebugger.enabled) {
       extendedDebugger(format(message, ...args))
     }

--- a/src/services/debug-factory-service.ts
+++ b/src/services/debug-factory-service.ts
@@ -1,0 +1,20 @@
+import { format } from "node:util"
+
+import * as coreDebugFactory from "debug"
+
+const rootDebugger = coreDebugFactory("entando-bundle-cli")
+
+export default function debugFactory(
+  caller: { name: string } | string
+): (message: string, ...args: any[]) => void {
+  const namespace = typeof caller === "string" ? caller : caller.name
+  const extendedDebugger = rootDebugger.extend(namespace)
+
+  return (message: string, ...args: any[]) => {
+    extendedDebugger.enabled =
+      extendedDebugger.enabled || process.env.ENTANDO_CLI_DEBUG === "true"
+    if (extendedDebugger.enabled) {
+      extendedDebugger(format(message, ...args))
+    }
+  }
+}

--- a/src/services/initializer.ts
+++ b/src/services/initializer.ts
@@ -3,6 +3,7 @@ import * as cp from "node:child_process"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import BundleDescriptorManager from "./bundle-descriptor-manager"
+import debugFactory from "./debug-factory-service"
 
 const ALLOWED_BUNDLE_NAME_REGEXP = /^[\w-]+$/
 
@@ -14,6 +15,8 @@ export interface InitializerOptions {
 
 /** Handles the scaffolding of a project bundle */
 export default class BundleProjectInitializer {
+  private static debug = debugFactory(BundleProjectInitializer)
+
   private readonly options: InitializerOptions
 
   constructor(options: InitializerOptions) {
@@ -21,6 +24,8 @@ export default class BundleProjectInitializer {
   }
 
   public async performScaffolding(): Promise<void> {
+    BundleProjectInitializer.debug("project scaffolding started")
+
     if (!ALLOWED_BUNDLE_NAME_REGEXP.test(this.options.name)) {
       throw new CLIError(
         `"${this.options.name}" is not a valid bundle name. Only alphanumeric characters, underscore and dash are allowed`
@@ -36,6 +41,8 @@ export default class BundleProjectInitializer {
   }
 
   private createBundleDirectories() {
+    BundleProjectInitializer.debug("creating bundle directories")
+
     const bundleDir = this.getBundleDirectory()
 
     try {
@@ -59,6 +66,8 @@ export default class BundleProjectInitializer {
   }
 
   private createBundleDescriptor() {
+    BundleProjectInitializer.debug("creating bundle descriptor")
+
     const bundleDescriptorManager = new BundleDescriptorManager(
       this.getBundleDirectory()
     )
@@ -69,6 +78,7 @@ export default class BundleProjectInitializer {
   }
 
   private createDockerfile() {
+    BundleProjectInitializer.debug("creating Dockerfile")
     this.createFileFromTemplate(
       this.getBundleFilePath("Dockerfile"),
       "Dockerfile-template"
@@ -76,6 +86,7 @@ export default class BundleProjectInitializer {
   }
 
   private createGitignore() {
+    BundleProjectInitializer.debug("creating .gitignore")
     this.createFileFromTemplate(
       this.getBundleFilePath(".gitignore"),
       "gitignore-template"
@@ -94,6 +105,7 @@ export default class BundleProjectInitializer {
   }
 
   private initGitRepo() {
+    BundleProjectInitializer.debug("initializing git repository")
     try {
       // Using stdio "pipe" option to print stderr only through CLIError
       cp.execSync(`git -C ${this.getBundleDirectory()} init`, { stdio: "pipe" })

--- a/test/services/debug-factory-service.test.ts
+++ b/test/services/debug-factory-service.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@oclif/test"
+
+import Init from "../../src/commands/init"
+import debugFactory from "../../src/services/debug-factory-service"
+
+describe("debugFactory", () => {
+  test
+    .stderr()
+    .env({ ENTANDO_CLI_DEBUG: "false" })
+    .do(() => {
+      const debug = debugFactory("disabled")
+      debug("should not appear")
+    })
+    .it("debugger disabled", ctx => {
+      expect(ctx.stderr).to.eq("")
+    })
+
+  test
+    .stderr()
+    .env({ ENTANDO_CLI_DEBUG: "true" })
+    .do(() => {
+      const debug = debugFactory(Init)
+      debug("simple message")
+    })
+    .it("debugger enabled using -d uses class name", ctx => {
+      expect(ctx.stderr).to.contain("entando-bundle-cli:Init simple message")
+    })
+
+  test
+    .stderr()
+    .env({ ENTANDO_CLI_DEBUG: "true" })
+    .do(() => {
+      const debug = debugFactory("test-namespace")
+      debug("%s message", "formatted")
+    })
+    .it("debugger enabled using -d prints formatted message", ctx => {
+      expect(ctx.stderr).to.contain(
+        "entando-bundle-cli:test-namespace formatted message"
+      )
+    })
+})

--- a/test/services/debug-factory-service.test.ts
+++ b/test/services/debug-factory-service.test.ts
@@ -6,7 +6,7 @@ import debugFactory from "../../src/services/debug-factory-service"
 describe("debugFactory", () => {
   test
     .stderr()
-    .env({ ENTANDO_CLI_DEBUG: "false" })
+    .env({ ENTANDO_BUNDLE_CLI_DEBUG: "false" })
     .do(() => {
       const debug = debugFactory("disabled")
       debug("should not appear")
@@ -17,7 +17,7 @@ describe("debugFactory", () => {
 
   test
     .stderr()
-    .env({ ENTANDO_CLI_DEBUG: "true" })
+    .env({ ENTANDO_BUNDLE_CLI_DEBUG: "true" })
     .do(() => {
       const debug = debugFactory(Init)
       debug("simple message")
@@ -28,7 +28,7 @@ describe("debugFactory", () => {
 
   test
     .stderr()
-    .env({ ENTANDO_CLI_DEBUG: "true" })
+    .env({ ENTANDO_BUNDLE_CLI_DEBUG: "true" })
     .do(() => {
       const debug = debugFactory("test-namespace")
       debug("%s message", "formatted")


### PR DESCRIPTION
Oclif [suggests](https://oclif.io/docs/debugging) to use the `debug` module for debug logging, since it is the one that it uses internally. I didn't add the dependency, since we can use the inherited one, however I had to add a rule to the linter to make it working.

I created a debugFactory function that can be used to define loggers inside the classes:

    private static debug = debugFactory(MyClass)

I named it `debug`, as done by the library, to avoid confusion with the `log()` method provided by Oclif `Command` class.

By default the library uses a colorful output in TTY mode and prepends timestamps in non TTY mode.

I didn't find a way to enable a global flag. I created a [custom command base class](https://oclif.io/docs/base_class) defining that flag. So all new commands have to inherit from this one.

Debug library can be activated using the environment variable `DEBUG`, which can take filters (`*` or specific logger namespaces). So `./bin/dev init mybundle -d` is equivalent to `DEBUG=entando-bundle-cli:\* ./bin/dev init mybundle`