### PR TITLE
ENG-3953 Improved validation of component names and versions

### DIFF
--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -26,6 +26,10 @@ import {
 } from '../services/bundle-thumbnail-service'
 import { PSCService } from '../services/psc-service'
 import { SUPPORTED_PSC_TYPES } from '../models/yaml-bundle-descriptor'
+import {
+  ALLOWED_VERSION_REGEXP,
+  INVALID_VERSION_MESSAGE
+} from '../models/bundle-descriptor-constraints'
 
 export default class Pack extends BaseBuildCommand {
   static description = 'Generate the bundle Docker images'
@@ -104,6 +108,14 @@ export default class Pack extends BaseBuildCommand {
     const microservices = componentService.getVersionedComponents(
       ComponentType.MICROSERVICE
     )
+
+    for (const microservice of microservices) {
+      if (!ALLOWED_VERSION_REGEXP.test(microservice.version)) {
+        this.error(
+          `Version of ${microservice.name} is not valid. ${INVALID_VERSION_MESSAGE}`
+        )
+      }
+    }
 
     this.log(color.bold.blue('Building microservices Docker images...'))
 

--- a/src/models/bundle-descriptor-constraints.ts
+++ b/src/models/bundle-descriptor-constraints.ts
@@ -29,10 +29,14 @@ import {
   maxLength
 } from '../services/constraints-validator-service'
 
-export const ALLOWED_NAME_REGEXP = /^[\w-]+$/
+export const ALLOWED_NAME_REGEXP = /^[\da-z]+(?:(\.|_{1,2}|-+)[\da-z]+)*$/
+export const ALLOWED_VERSION_REGEXP = /^\w+[\w.-]*$/
+export const MAX_VERSION_LENGTH = 128
 export const MAX_NAME_LENGTH = 50
 export const INVALID_NAME_MESSAGE =
-  'Only alphanumeric characters, underscore and dash are allowed'
+  'Name components may contain lowercase letters, digits and separators. A separator is defined as a period, one or two underscores, or one or more dashes. A name component may not start or end with a separator.'
+export const INVALID_VERSION_MESSAGE =
+  'Version may contain lowercase and uppercase letters, digits, underscores, periods and dashes. Version may not start with a period or a dash.'
 export const ALLOWED_BUNDLE_WITHOUT_REGISTRY_REGEXP = /^[\w-]+\/[\w-]+$/
 export const ALLOWED_BUNDLE_WITH_REGISTRY_REGEXP =
   /^[\w.-]+(:\d+)?(?:\/[\w-]+){2}$/
@@ -43,6 +47,10 @@ export const VALID_CONTEXT_PARAM_FORMAT =
   'Valid format for a contextParam is <code>_<value> where:\n - code is one of: page, info or systemParam\n - value is an alphanumeric string'
 
 const nameRegExpValidator = regexp(ALLOWED_NAME_REGEXP, INVALID_NAME_MESSAGE)
+const versionRegExpValidator = regexp(
+  ALLOWED_VERSION_REGEXP,
+  INVALID_VERSION_MESSAGE
+)
 const nameLengthValidator = maxLength(MAX_NAME_LENGTH)
 const bundleRegExpValidator = regexp(
   ALLOWED_BUNDLE_WITH_REGISTRY_REGEXP,
@@ -565,7 +573,8 @@ export const BUNDLE_DESCRIPTOR_CONSTRAINTS: ObjectConstraints<BundleDescriptor> 
     },
     version: {
       required: true,
-      type: 'string'
+      type: 'string',
+      validators: [versionRegExpValidator, maxLength(MAX_VERSION_LENGTH)]
     },
     type: {
       required: true,

--- a/test/commands/pack.test.ts
+++ b/test/commands/pack.test.ts
@@ -412,6 +412,26 @@ describe('pack', () => {
       sinon.assert.calledOnce(stubGenerateYamlDescriptors)
     })
 
+  test
+    .stdout()
+    .stderr()
+    .do(() => {
+      tempDirHelper.createInitializedBundleDir('test-invalid-version')
+      sinon.stub(ComponentService.prototype, 'getVersionedComponents').returns([
+        {
+          name: 'invalid-ms',
+          type: ComponentType.MICROSERVICE,
+          stack: MicroserviceStack.SpringBoot,
+          version: 'invalid version'
+        }
+      ])
+    })
+    .command(['pack', '--org', 'flag-organization'])
+    .catch(error => {
+      expect(error.message).contain('Version of invalid-ms is not valid')
+    })
+    .it('Pack fails if microservices versions are invalid')
+
   function setupBuildSuccess(bundleDir: string) {
     const stubComponents = [
       {

--- a/test/services/constraints-validator-service.test.ts
+++ b/test/services/constraints-validator-service.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   BUNDLE_DESCRIPTOR_CONSTRAINTS,
   INVALID_NAME_MESSAGE,
+  INVALID_VERSION_MESSAGE,
   VALID_CONTEXT_PARAM_FORMAT
 } from '../../src/models/bundle-descriptor-constraints'
 import { BundleDescriptorHelper } from '../helpers/mocks/bundle-descriptor-helper'
@@ -589,106 +590,194 @@ describe('BundleDescriptorValidatorService', () => {
       expect(error.message).contain('$.microfrontends[0].params')
     })
     .it('Validates micro frontend with invalid params field')
+
+  test
+    .do(() => {
+      const invalidDescriptor: any =
+        BundleDescriptorHelper.newBundleDescriptor()
+      invalidDescriptor.microfrontends[1].configMfe = 'config-mfe'
+
+      ConstraintsValidatorService.validateObjectConstraints(
+        invalidDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .catch(error => {
+      expect(error.message).contain(
+        'Field "configMfe" requires field "type" to have value: widget'
+      )
+      expect(error.message).contain('$.microfrontends[1]')
+    })
+    .it('Validates micro frontend configMfe field dependency')
+
+  test
+    .do(() => {
+      const invalidDescriptor: any =
+        BundleDescriptorHelper.newBundleDescriptor()
+      invalidDescriptor.microfrontends[0].configMfe = 'test-mfe-1'
+
+      ConstraintsValidatorService.validateObjectConstraints(
+        invalidDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .catch(error => {
+      expect(error.message).contain(
+        'Field "configMfe" value must not be equal to field "name" value'
+      )
+      expect(error.message).contain('$.microfrontends[0]')
+    })
+    .it(
+      'Validates widget micro frontend with configMfe field value equal to name field value'
+    )
+
+  test
+    .do(() => {
+      const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+      invalidDescriptor.name = 'too-long'.repeat(20)
+
+      ConstraintsValidatorService.validateObjectConstraints(
+        invalidDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .catch(error => {
+      expect(error.message).contain('Field "name" is too long')
+      expect(error.message).contain('$.name')
+    })
+    .it('Validates bundle name too long')
+
+  test
+    .do(() => {
+      const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+      invalidDescriptor.microservices[0].name = 'too-long'.repeat(20)
+
+      ConstraintsValidatorService.validateObjectConstraints(
+        invalidDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .catch(error => {
+      expect(error.message).contain('Field "name" is too long')
+      expect(error.message).contain('$.microservices[0].name')
+    })
+    .it('Validates microservices name too long')
+
+  test
+    .do(() => {
+      const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+      invalidDescriptor.microfrontends[0].name = 'too-long'.repeat(20)
+
+      ConstraintsValidatorService.validateObjectConstraints(
+        invalidDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .catch(error => {
+      expect(error.message).contain('Field "name" is too long')
+      expect(error.message).contain('$.microfrontends[0].name')
+    })
+    .it('Validates microfrontend name too long')
+
+  test
+    .do(() => {
+      const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+      invalidDescriptor.microservices[0].ingressPath = 'too-long'.repeat(20)
+
+      ConstraintsValidatorService.validateObjectConstraints(
+        invalidDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .catch(error => {
+      expect(error.message).contain('Field "ingressPath" is too long')
+      expect(error.message).contain('$.microservices[0].ingressPath')
+    })
+    .it('Validates ingressPath too long')
+
+  testInvalidBundleName('--starts-with-separator')
+  testInvalidBundleName('ends-with-separator--')
+  testInvalidBundleName('invalid___separator')
+  testInvalidBundleName('invalid..separator')
+  testInvalidBundleName('INVALID-NAME')
+  testInvalidBundleName('invalid name with spaces')
+
+  function testInvalidBundleName(invalidBundleName: string) {
+    test
+      .do(() => {
+        const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+        invalidDescriptor.name = invalidBundleName
+        ConstraintsValidatorService.validateObjectConstraints(
+          invalidDescriptor,
+          BUNDLE_DESCRIPTOR_CONSTRAINTS
+        )
+      })
+      .catch(error => {
+        expect(error.message).contain(
+          'Field "name" is not valid. ' + INVALID_NAME_MESSAGE
+        )
+        expect(error.message).contain('$.name')
+      })
+      .it(`Validates invalid bundle name "${invalidBundleName}"`)
+  }
+
+  test
+    .do(() => {
+      const validDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+      validDescriptor.name = 'this---name__is.valid-123_abc'
+      ConstraintsValidatorService.validateObjectConstraints(
+        validDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .it('Validates valid bundle name')
+
+  testInvalidBundleVersion('.invalid-start-with-period')
+  testInvalidBundleVersion('-invalid-start-with-dash')
+  testInvalidBundleVersion('invalid version')
+
+  function testInvalidBundleVersion(invalidVersion: string) {
+    test
+      .do(() => {
+        const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+        invalidDescriptor.version = invalidVersion
+        ConstraintsValidatorService.validateObjectConstraints(
+          invalidDescriptor,
+          BUNDLE_DESCRIPTOR_CONSTRAINTS
+        )
+      })
+      .catch(error => {
+        expect(error.message).contain(
+          'Field "version" is not valid. ' + INVALID_VERSION_MESSAGE
+        )
+        expect(error.message).contain('$.version')
+      })
+      .it(`Validates invalid bundle version "${invalidVersion}"`)
+  }
+
+  test
+    .do(() => {
+      const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+      invalidDescriptor.version = 'x'.repeat(500)
+      ConstraintsValidatorService.validateObjectConstraints(
+        invalidDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .catch(error => {
+      expect(error.message).contain('Field "version" is too long')
+      expect(error.message).contain('$.version')
+    })
+    .it('Validates bundle version too long')
+
+  test
+    .do(() => {
+      const validDescriptor = BundleDescriptorHelper.newBundleDescriptor()
+      validDescriptor.version = '__this---version__is.VALID-123_abc__'
+      ConstraintsValidatorService.validateObjectConstraints(
+        validDescriptor,
+        BUNDLE_DESCRIPTOR_CONSTRAINTS
+      )
+    })
+    .it('Validates valid bundle version')
 })
-
-test
-  .do(() => {
-    const invalidDescriptor: any = BundleDescriptorHelper.newBundleDescriptor()
-    invalidDescriptor.microfrontends[1].configMfe = 'config-mfe'
-
-    ConstraintsValidatorService.validateObjectConstraints(
-      invalidDescriptor,
-      BUNDLE_DESCRIPTOR_CONSTRAINTS
-    )
-  })
-  .catch(error => {
-    expect(error.message).contain(
-      'Field "configMfe" requires field "type" to have value: widget'
-    )
-    expect(error.message).contain('$.microfrontends[1]')
-  })
-  .it('Validates micro frontend configMfe field dependency')
-
-test
-  .do(() => {
-    const invalidDescriptor: any = BundleDescriptorHelper.newBundleDescriptor()
-    invalidDescriptor.microfrontends[0].configMfe = 'test-mfe-1'
-
-    ConstraintsValidatorService.validateObjectConstraints(
-      invalidDescriptor,
-      BUNDLE_DESCRIPTOR_CONSTRAINTS
-    )
-  })
-  .catch(error => {
-    expect(error.message).contain(
-      'Field "configMfe" value must not be equal to field "name" value'
-    )
-    expect(error.message).contain('$.microfrontends[0]')
-  })
-  .it(
-    'Validates widget micro frontend with configMfe field value equal to name field value'
-  )
-
-test
-  .do(() => {
-    const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
-    invalidDescriptor.name = 'too-long'.repeat(20)
-
-    ConstraintsValidatorService.validateObjectConstraints(
-      invalidDescriptor,
-      BUNDLE_DESCRIPTOR_CONSTRAINTS
-    )
-  })
-  .catch(error => {
-    expect(error.message).contain('Field "name" is too long')
-    expect(error.message).contain('$.name')
-  })
-  .it('Validates bundle name too long')
-
-test
-  .do(() => {
-    const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
-    invalidDescriptor.microservices[0].name = 'too-long'.repeat(20)
-
-    ConstraintsValidatorService.validateObjectConstraints(
-      invalidDescriptor,
-      BUNDLE_DESCRIPTOR_CONSTRAINTS
-    )
-  })
-  .catch(error => {
-    expect(error.message).contain('Field "name" is too long')
-    expect(error.message).contain('$.microservices[0].name')
-  })
-  .it('Validates microservices name too long')
-
-test
-  .do(() => {
-    const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
-    invalidDescriptor.microfrontends[0].name = 'too-long'.repeat(20)
-
-    ConstraintsValidatorService.validateObjectConstraints(
-      invalidDescriptor,
-      BUNDLE_DESCRIPTOR_CONSTRAINTS
-    )
-  })
-  .catch(error => {
-    expect(error.message).contain('Field "name" is too long')
-    expect(error.message).contain('$.microfrontends[0].name')
-  })
-  .it('Validates microfrontend name too long')
-
-test
-  .do(() => {
-    const invalidDescriptor = BundleDescriptorHelper.newBundleDescriptor()
-    invalidDescriptor.microservices[0].ingressPath = 'too-long'.repeat(20)
-
-    ConstraintsValidatorService.validateObjectConstraints(
-      invalidDescriptor,
-      BUNDLE_DESCRIPTOR_CONSTRAINTS
-    )
-  })
-  .catch(error => {
-    expect(error.message).contain('Field "ingressPath" is too long')
-    expect(error.message).contain('$.microservices[0].ingressPath')
-  })
-  .it('Validates ingressPath too long')


### PR DESCRIPTION
Some considerations:

- microservices version format could be checked at each command (in `BundleService`) however that would imply reading all the pom.xml files every time, so I put that validation only inside the pack command (where Docker build would fail if the microservice version doesn't use valid Docker tag format).
- RegExp for bundle format in API claims is kept simpler, since our commands don't fail for that. Let me know if you prefer to have a stricter validation on it.
- I set maximum version length to 128 (as required by Docker). Since component name length is limited to 50 characters I find this a bit weird. Let me know if you prefer to set a lower limit on it.