### PR TITLE
ENG-3939 refactor fs-service class

### DIFF
--- a/src/services/bundle-service.ts
+++ b/src/services/bundle-service.ts
@@ -1,12 +1,6 @@
 import { BundleDescriptorService } from './bundle-descriptor-service'
 import * as crypto from 'node:crypto'
 import * as path from 'node:path'
-import {
-  MICROFRONTENDS_FOLDER,
-  MICROSERVICES_FOLDER,
-  PSC_FOLDER,
-  SVC_FOLDER
-} from '../paths'
 import { FSService } from './fs-service'
 
 export class BundleService {
@@ -18,10 +12,7 @@ export class BundleService {
       path.dirname(process.cwd())
     )
 
-    fsService.createEmptySubDirectoryForGitIfNotExist(PSC_FOLDER)
-    fsService.createEmptySubDirectoryForGitIfNotExist(SVC_FOLDER)
-    fsService.createEmptySubDirectoryForGitIfNotExist(MICROFRONTENDS_FOLDER)
-    fsService.createEmptySubDirectoryForGitIfNotExist(MICROSERVICES_FOLDER)
+    fsService.createEmptySubdirectoriesForGitIfNotExist()
   }
 
   public static generateBundleId(bundle: string): string {

--- a/src/services/initializer-service.ts
+++ b/src/services/initializer-service.ts
@@ -1,16 +1,18 @@
 import * as fs from 'node:fs'
+import { CLIError } from '@oclif/errors'
 import { BundleDescriptorService } from './bundle-descriptor-service'
 import { debugFactory } from './debug-factory-service'
 import {
-  SVC_FOLDER,
   CONFIG_FILE,
   CONFIG_FOLDER,
   DEFAULT_CONFIG_FILE,
-  OUTPUT_FOLDER,
-  MICROFRONTENDS_FOLDER,
-  MICROSERVICES_FOLDER,
-  PSC_FOLDER,
+  OUTPUT_FOLDER
 } from '../paths'
+import {
+  ALLOWED_NAME_REGEXP,
+  INVALID_NAME_MESSAGE,
+  MAX_NAME_LENGTH
+} from '../models/bundle-descriptor-constraints'
 
 import { FSService } from './fs-service'
 import { GitService } from './git-service'
@@ -41,7 +43,7 @@ export class InitializerService {
   public async performBundleInit(): Promise<void> {
     InitializerService.debug('project scaffolding started')
 
-    this.filesys.checkBundleName()
+    this.checkBundleName()
     this.createBundleDirectories()
     this.createBundleDescriptor()
     this.createGitignore()
@@ -49,10 +51,44 @@ export class InitializerService {
     await this.git.initRepo()
   }
 
+  public checkBundleName(): void {
+    InitializerService.debug('checking if bundle name is valid')
+    const { name } = this.options
+    if (!ALLOWED_NAME_REGEXP.test(name)) {
+      throw new CLIError(
+        `'${name}' is not a valid bundle name. ${INVALID_NAME_MESSAGE}`
+      )
+    }
+
+    if (name.length > MAX_NAME_LENGTH) {
+      throw new CLIError(
+        `Bundle name is too long. The maximum length is ${MAX_NAME_LENGTH}`
+      )
+    }
+  }
+
+  public checkBundleDirectory(): void {
+    InitializerService.debug('checking bundle directory if we have access')
+
+    const { parentDirectory } = this.options
+    const bundleDir = this.filesys.getBundleDirectory()
+
+    try {
+      fs.accessSync(parentDirectory, fs.constants.W_OK)
+    } catch {
+      throw new CLIError(`Directory ${parentDirectory} is not writable`)
+    }
+
+    InitializerService.debug('checking bundle directory it exists')
+    if (fs.existsSync(bundleDir)) {
+      throw new CLIError(`Directory ${bundleDir} already exists`)
+    }
+  }
+
   private createBundleDirectories() {
     InitializerService.debug('creating bundle directories')
 
-    this.filesys.checkBundleDirectory()
+    this.checkBundleDirectory()
 
     const bundleDir = this.filesys.getBundleDirectory()
 
@@ -60,10 +96,7 @@ export class InitializerService {
     fs.mkdirSync(this.filesys.getBundleFilePath(...OUTPUT_FOLDER), {
       recursive: true
     })
-    this.filesys.createEmptySubDirectoryForGitIfNotExist(MICROSERVICES_FOLDER)
-    this.filesys.createEmptySubDirectoryForGitIfNotExist(MICROFRONTENDS_FOLDER)
-    this.filesys.createEmptySubDirectoryForGitIfNotExist(PSC_FOLDER)
-    fs.mkdirSync(this.filesys.getBundleFilePath(SVC_FOLDER))
+    this.filesys.createEmptySubdirectoriesForGitIfNotExist()
   }
 
   public async performBundleInitFromGit(
@@ -72,7 +105,7 @@ export class InitializerService {
     InitializerService.debug('cloning from bundle and creating new project')
     const { name, version } = this.options
 
-    this.filesys.checkBundleName()
+    this.checkBundleName()
     await this.git.cloneRepo(gitSrcRepoAddress)
     this.git.degit()
     await this.git.initRepo()
@@ -91,12 +124,9 @@ export class InitializerService {
   }
 
   private async createDefaultDirectories() {
-    this.filesys.createEmptySubDirectoryForGitIfNotExist(MICROSERVICES_FOLDER)
-    this.filesys.createEmptySubDirectoryForGitIfNotExist(MICROFRONTENDS_FOLDER)
-    this.filesys.createEmptySubDirectoryForGitIfNotExist(PSC_FOLDER)
+    this.filesys.createEmptySubdirectoriesForGitIfNotExist()
     this.filesys.createSubDirectoryIfNotExist(CONFIG_FOLDER)
     this.filesys.createSubDirectoryIfNotExist(...OUTPUT_FOLDER)
-    this.filesys.createSubDirectoryIfNotExist(SVC_FOLDER)
   }
 
   private createBundleDescriptor() {

--- a/test/services/fs-service.test.ts
+++ b/test/services/fs-service.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors'
 import { expect, test } from '@oclif/test'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
@@ -28,26 +27,6 @@ describe('fs-service', () => {
 
   after(() => {
     fs.rmSync(path.resolve(os.tmpdir(), writeJSONtestFile))
-  })
-
-  test.it('run checkBundleName', () => {
-    const filesys = new FSService(defaultBundleName, tempDirHelper.tmpDir)
-    expect(() => filesys.checkBundleName()).to.not.throw(CLIError)
-  })
-
-  test.it('run checkBundleName but has error', () => {
-    const filesys = new FSService('124!@', tempDirHelper.tmpDir)
-    expect(() => filesys.checkBundleName()).to.throw(CLIError)
-  })
-
-  test.it('run checkBundleDirectory', () => {
-    const filesys = new FSService(defaultBundleName, tempDirHelper.tmpDir)
-    expect(() => filesys.checkBundleDirectory()).to.not.throw(CLIError)
-  })
-
-  test.it('run checkBundleDirectory but has error', () => {
-    const filesys = new FSService('existing-bundle', tempDirHelper.tmpDir)
-    expect(() => filesys.checkBundleDirectory()).to.throw(CLIError)
   })
 
   test.it('run getBundleDirectory', () => {


### PR DESCRIPTION
 - The params `name` has been misunderstood to represent bundle name (found in bundle descriptor) instead of bundle folder name. parameter has been re-labeled to ensure the first parameter is meant for the bundle's folder name
 - `checkBundleName` and `checkBundleDirectory` has been moved out from `fs-service` to `initializer-service` since both are only intended for init use only
 - `createEmptySubDirectoryForGitIfNotExist` has been invoked repetitively on various areas, both on `initializer-service` and `bundle-service`. so I have created `createEmptySubdirectoriesForGitIfNotExist` that checks (and create) the 4 needed directories to reduce code lines