### PR TITLE
Multi-Arch BUILDX CLI tidbits

### DIFF
--- a/src/services/docker-service.ts
+++ b/src/services/docker-service.ts
@@ -81,7 +81,7 @@ export class DockerService {
       options.name,
       options.tag
     )
-    return `${DOCKER_COMMAND} buildx build --push --platform "linux/arm64,linux/amd64" -f ${dockerfile} -t ${dockerImageName} .`
+    return `${DOCKER_COMMAND} buildx build --push --platform "linux/arm64,linux/amd64" -f ${dockerfile} -t registry.entando-poc.ipponusa.com/${dockerImageName} .`
   }
 
   public static getBundleDockerfile(

--- a/src/services/docker-service.ts
+++ b/src/services/docker-service.ts
@@ -81,7 +81,7 @@ export class DockerService {
       options.name,
       options.tag
     )
-    return `${DOCKER_COMMAND} build --platform "linux/amd64" -f ${dockerfile} -t ${dockerImageName} .`
+    return `${DOCKER_COMMAND} build --platform "linux/arm64" -f ${dockerfile} -t ${dockerImageName} .`
   }
 
   public static getBundleDockerfile(

--- a/src/services/docker-service.ts
+++ b/src/services/docker-service.ts
@@ -81,7 +81,7 @@ export class DockerService {
       options.name,
       options.tag
     )
-    return `${DOCKER_COMMAND} build --platform "linux/arm64" -f ${dockerfile} -t ${dockerImageName} .`
+    return `${DOCKER_COMMAND} buildx build --push --platform "linux/arm64,linux/amd64" -f ${dockerfile} -t ${dockerImageName} .`
   }
 
   public static getBundleDockerfile(

--- a/test/services/docker-service.test.ts
+++ b/test/services/docker-service.test.ts
@@ -48,7 +48,7 @@ describe('DockerService', () => {
       sinon.match({
         command:
           DOCKER_COMMAND +
-          ' build --platform "linux/arm64" -f Dockerfile -t my-org/bundle-name:0.0.1 .'
+          ' buildx build --push --platform "linux/arm64,linux/amd64" -f Dockerfile -t my-org/bundle-name:0.0.1 .'
       })
     )
   })
@@ -72,7 +72,7 @@ describe('DockerService', () => {
       sinon.match({
         command:
           DOCKER_COMMAND +
-          ' build --platform "linux/arm64" -f my-Dockerfile -t my-org/bundle-name:0.0.1 .'
+          ' buildx build --push --platform "linux/arm64,linux/amd64" -f my-Dockerfile -t my-org/bundle-name:0.0.1 .'
       })
     )
   })

--- a/test/services/docker-service.test.ts
+++ b/test/services/docker-service.test.ts
@@ -48,7 +48,7 @@ describe('DockerService', () => {
       sinon.match({
         command:
           DOCKER_COMMAND +
-          ' buildx build --push --platform "linux/arm64,linux/amd64" -f Dockerfile -t my-org/bundle-name:0.0.1 .'
+          ' buildx build --push --platform "linux/arm64,linux/amd64" -f Dockerfile -t registry.entando-poc.ipponusa.com/my-org/bundle-name:0.0.1 .'
       })
     )
   })
@@ -72,7 +72,7 @@ describe('DockerService', () => {
       sinon.match({
         command:
           DOCKER_COMMAND +
-          ' buildx build --push --platform "linux/arm64,linux/amd64" -f my-Dockerfile -t my-org/bundle-name:0.0.1 .'
+          ' buildx build --push --platform "linux/arm64,linux/amd64" -f my-Dockerfile -t registry.entando-poc.ipponusa.com/my-org/bundle-name:0.0.1 .'
       })
     )
   })
@@ -113,7 +113,7 @@ describe('DockerService', () => {
       executeProcessStub,
       sinon.match({
         command: sinon.match(
-          '.entando/output/Dockerfile -t my-org/test-bundle:0.0.1'
+          '.entando/output/Dockerfile -t registry.entando-poc.ipponusa.com/my-org/test-bundle:0.0.1'
         )
       })
     )
@@ -140,7 +140,9 @@ describe('DockerService', () => {
     sinon.assert.calledWith(
       executeProcessStub,
       sinon.match({
-        command: sinon.match('custom-Dockerfile -t my-org/test-bundle:0.0.1')
+        command: sinon.match(
+          'custom-Dockerfile -t registry.entando-poc.ipponusa.com/my-org/test-bundle:0.0.1'
+        )
       })
     )
     const generatedDockerfile = path.resolve(

--- a/test/services/docker-service.test.ts
+++ b/test/services/docker-service.test.ts
@@ -48,7 +48,7 @@ describe('DockerService', () => {
       sinon.match({
         command:
           DOCKER_COMMAND +
-          ' build --platform "linux/amd64" -f Dockerfile -t my-org/bundle-name:0.0.1 .'
+          ' build --platform "linux/arm64" -f Dockerfile -t my-org/bundle-name:0.0.1 .'
       })
     )
   })
@@ -72,7 +72,7 @@ describe('DockerService', () => {
       sinon.match({
         command:
           DOCKER_COMMAND +
-          ' build --platform "linux/amd64" -f my-Dockerfile -t my-org/bundle-name:0.0.1 .'
+          ' build --platform "linux/arm64" -f my-Dockerfile -t my-org/bundle-name:0.0.1 .'
       })
     )
   })


### PR DESCRIPTION
Here were the "touch points and learnings" that we came across while shooting for building a multi-arch container using the CLI. I don't expect this pull request to be merged, but wanted to share our findings.  Please note, our private registry is hard coded, - again, this PR is to just serve as a reference and act as a way to share our notes.

- BuildX requires some additional configuration regarding setting the buildx backend
  - looks like this: `docker buildx create --use --driver-opt network=host --buildkitd-flags '--debug --allow-insecure-entitlement network.host'`
- Entando work flow is like: pack and then publish, which didn't fit great with the buildx model.
  - without a registry to put the multiarch images in, one image would be stored locally and the other would be cached... To work around this, we made the pack command push to our registry with --push, which goes slightly outside the Entando work flow.
- We quickly realized that any remaining distance down this path would likely include the custom operator and application code changes, so we decided to stop there.