### PR TITLE
ENG-4867 Ensure closing of file stream after each component build

### DIFF
--- a/src/services/process-executor-service.ts
+++ b/src/services/process-executor-service.ts
@@ -141,6 +141,14 @@ export class ParallelProcessExecutorService extends EventEmitter {
         this.emit('done', queuedExecution.index, code ?? signal!)
       })
 
+      process.on('close', (code, signal) => {
+        ParallelProcessExecutorService.debug(
+          `Process ${queuedExecution.index} closed with code ${code} and signal ${signal}`
+        )
+
+        queuedExecution.options.outputStream?.end()
+      })
+
       process.on('error', error => {
         ParallelProcessExecutorService.debug(
           `Process ${queuedExecution.index} exited due to error`,

--- a/test/helpers/mocks/fake-stream.ts
+++ b/test/helpers/mocks/fake-stream.ts
@@ -1,0 +1,15 @@
+import { Writable } from 'node:stream'
+
+export class FakeStream extends Writable {
+  _write(
+    chunk: any,
+    encoding: string,
+    callback: (error?: Error | null) => void
+  ): void {
+    callback()
+  }
+
+  end(cb?: () => void): this {
+    return super.end(cb)
+  }
+}


### PR DESCRIPTION
Resolves an issue where a locked file stream after the initial build processes when running the pack command causes problems with the subsequent `docker build` (using podman) process. The file stream is now manually closed with `end()` after each initial build process finishes.