### PR TITLE
fix: update the actual max length for bundle names

### DIFF
--- a/src/models/bundle-descriptor-constraints.ts
+++ b/src/models/bundle-descriptor-constraints.ts
@@ -38,7 +38,7 @@ import {
 export const ALLOWED_NAME_REGEXP = /^[\da-z]+(?:([.-])[\da-z]+)*$/
 export const ALLOWED_VERSION_REGEXP = /^\w+[\w.-]*$/
 export const MAX_VERSION_LENGTH = 128
-export const MAX_NAME_LENGTH = 50
+export const MAX_NAME_LENGTH = 31
 export const MAX_WIDGET_CATEGORY_LENGTH = 80
 export const INVALID_NAME_MESSAGE =
   'The Name may contain lowercase letters, digits and separators. A separator is defined as a period, or a dash. The name may not start or end with a separator.'


### PR DESCRIPTION
## What?

Update the `MAX_NAME_LENGTH` constraint used by the bundle CLI

## Why?

Upon using the entnado cli and app-builder, I came into the situation where packing the bundle was successful however the app-builder always gave 500 error when trying to install the bundle.
There was no specific error thus I had to look into the pod logs to understand that the database was throwing error mentioning that the max length can be 40.

## How?

Since entando already appends 8 unique alphanumeric ID and a separator, the only possible length for the 40 character limit is 31 (40 - 9)